### PR TITLE
fix: user slug

### DIFF
--- a/src/Content/AddCboxIFrame.php
+++ b/src/Content/AddCboxIFrame.php
@@ -44,10 +44,12 @@ class AddCboxIFrame
         if ($actor->exists) {
             $color = Color::stringToColor($actor->display_name);
 
+            $slug = $this->setting->get('slug_driver_Flarum\User\User') === 'default' ? 'username' : 'id';
+
             $params = [
                 ...$params,
                 'nme' => $actor->display_name,
-                'lnk' => $this->url->to('forum')->route('user', ['username' => $actor->username]),
+                'lnk' => $this->url->to('forum')->route('user', ['username' => $actor->$slug]),
                 'pic' => $actor->avatar_url ?? "https://ui-avatars.com/api/?background=$color&color=fff&name=D",
             ];
         }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Tóm tắt bởi Sourcery

Sửa lỗi xử lý user slug trong lớp AddCboxIFrame để lựa chọn động giữa 'username' và 'id' dựa trên cài đặt cấu hình, đảm bảo tạo liên kết người dùng chính xác.

Sửa lỗi:
- Sửa lỗi xử lý user slug bằng cách lựa chọn động giữa 'username' và 'id' dựa trên cài đặt cấu hình.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the user slug handling in the AddCboxIFrame class to dynamically choose between 'username' and 'id' based on the configuration settings, ensuring correct user link generation.

Bug Fixes:
- Fix user slug handling by dynamically selecting between 'username' and 'id' based on configuration settings.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->